### PR TITLE
Update Restricted FW Rule to use latest CAI field names

### DIFF
--- a/policies/templates/gcp_restricted_firewall_rules_v1.yaml
+++ b/policies/templates/gcp_restricted_firewall_rules_v1.yaml
@@ -300,7 +300,7 @@ spec:
         
         # fw_rule_check_protocol when one ip_configs is set to "all"
         fw_rule_check_protocol_and_port(ip_configs, protocol, port) {
-        	ip_configs[_].ipProtocol == "all"
+        	ip_configs[_].IPProtocol == "all"
         }
         
         # fw_rule_check_protocol when protocol is set to any
@@ -314,7 +314,7 @@ spec:
         	protocol != "any"
         
         	# Check if the protocol is in the rule
-        	ip_configs[i].ipProtocol == protocol
+        	ip_configs[i].IPProtocol == protocol
         
         	# Check if the associated port is also a match
         fw_rule_check_port(	ip_configs[i], port)
@@ -330,10 +330,10 @@ spec:
         	protocol_with_ports := {"tcp", "udp", "all"}
         
         	# only for protocol with ports or "all" - since it includes tcp and udp
-        	ip_config.ipProtocol == protocol_with_ports[_]
+        	ip_config.IPProtocol == protocol_with_ports[_]
         
         	# if port is not set in ip_config, any port passed as a param matches
-        not 	ip_config.port
+        not 	ip_config.ports
         }
         
         # fw_rule_check_port when port is a single number
@@ -342,7 +342,7 @@ spec:
         	not re_match("-", port)
         
         	# check if the port matches
-        	rule_ports := ip_config.port
+        	rule_ports := ip_config.ports
         
         	# check if port is in one of rule_ports values
         port_is_in_values(	port, rule_ports[_])
@@ -354,7 +354,7 @@ spec:
         	re_match("-", port)
         
         	# check if the port range is included in the fw_rule port
-        	rule_ports := ip_config.port
+        	rule_ports := ip_config.ports
         
         	rule_port := rule_ports[_]
         
@@ -424,11 +424,11 @@ spec:
         
         # fw_rule_check_source when source range is passed
         fw_rule_check_source_range(fw_rule, source_range) {
-        	# test if sourceRange exists in the rule
-        	fw_rule.sourceRange
+        	# test if sourceRanges exists in the rule
+        	fw_rule.sourceRanges
         
         	# check that source ranges are set
-        	fw_rule_ranges = fw_rule.sourceRange
+        	fw_rule_ranges = fw_rule.sourceRanges
         
         	# check if any range matches
         	# no CIDR matching logic at this time
@@ -440,7 +440,7 @@ spec:
         	source_range == "*"
         
         	# Check that at least a source range is set
-        	fw_rule.sourceRange
+        	fw_rule.sourceRanges
         }
         
         # fw_rule_check_source_range if source_ranges is set to any (default)
@@ -453,7 +453,7 @@ spec:
         	source_tag != "*"
         
         	# check that the rule source tags are set
-        	fw_rule_source_tags := fw_rule.sourceTag
+        	fw_rule_source_tags := fw_rule.sourceTags
         
         	# check if the input tag matches any tag in the rule
         re_match(	source_tag, fw_rule_source_tags[_])
@@ -464,7 +464,7 @@ spec:
         	source_tag == "*"
         
         	# Verify that we have a source tag set, regardless of its value
-        	fw_rule.sourceTag
+        	fw_rule.sourceTags
         }
         
         # fw_rule_check_source_tag if source tag is set to any (default)
@@ -477,7 +477,7 @@ spec:
         	source_service_account != "*"
         
         	# check that source service accounts are set
-        	fw_rule_source_sas = fw_rule.sourceServiceAccount
+        	fw_rule_source_sas = fw_rule.sourceServiceAccounts
         
         	# check if the rule service account matches
         re_match(	source_service_account, fw_rule_source_sas[_])
@@ -488,7 +488,7 @@ spec:
         	source_service_account == "*"
         
         	# Verify that we have a source service account set, regardless of its value
-        	fw_rule.sourceServiceAccount
+        	fw_rule.sourceServiceAccounts
         }
         
         # fw_rule_check_source_sas if source service account is set to any
@@ -509,11 +509,11 @@ spec:
         
         # fw_rule_check_target when target range is passed
         fw_rule_check_target_range(fw_rule, target_range) {
-        	# test if destinationRange exists in the rule
-        	fw_rule.destinationRange
+        	# test if destinationRanges exists in the rule
+        	fw_rule.destinationRanges
         
         	# check that target ranges are set
-        	fw_rule_ranges = fw_rule.destinationRange
+        	fw_rule_ranges = fw_rule.destinationRanges
         
         	# check if any range matches
         	# no CIDR matching logic at this time
@@ -525,7 +525,7 @@ spec:
         	target_range == "*"
         
         	# Check that at least a target range is set
-        	fw_rule.destinationRange
+        	fw_rule.destinationRanges
         }
         
         # fw_rule_check_target_range if target_ranges is set to any (default)
@@ -538,7 +538,7 @@ spec:
         	target_tag != "*"
         
         	# check that the rule target tags are set
-        	fw_rule_target_tags := fw_rule.targetTag
+        	fw_rule_target_tags := fw_rule.targetTags
         
         	# check if the input tag matches any tag in the rule
         re_match(	target_tag, fw_rule_target_tags[_])
@@ -549,7 +549,7 @@ spec:
         	target_tag == "*"
         
         	# Verify that we have a target tag set, regardless of its value
-        	fw_rule.targetTag
+        	fw_rule.targetTags
         }
         
         # fw_rule_check_target_tag if target tag is set to any (default)
@@ -562,7 +562,7 @@ spec:
         	target_service_account != "*"
         
         	# check that target service accounts are set
-        	fw_rule_target_sas = fw_rule.targetServiceAccount
+        	fw_rule_target_sas = fw_rule.targetServiceAccounts
         
         	# check if the rule service account matches
         re_match(	target_service_account, fw_rule_target_sas[_])
@@ -573,7 +573,7 @@ spec:
         	target_service_account == "*"
         
         	# Verify that we have a target service account set, regardless of its value
-        	fw_rule.targetServiceAccount
+        	fw_rule.targetServiceAccounts
         }
         
         # fw_rule_check_target_sas if target service account is set to any

--- a/validator/restricted_firewall_rules.rego
+++ b/validator/restricted_firewall_rules.rego
@@ -136,7 +136,7 @@ fw_rule_get_ip_configs(fw_rule, rule_type) = ip_configs {
 
 # fw_rule_check_protocol when one ip_configs is set to "all"
 fw_rule_check_protocol_and_port(ip_configs, protocol, port) {
-	ip_configs[_].ipProtocol == "all"
+	ip_configs[_].IPProtocol == "all"
 }
 
 # fw_rule_check_protocol when protocol is set to any
@@ -150,7 +150,7 @@ fw_rule_check_protocol_and_port(ip_configs, protocol, port) {
 	protocol != "any"
 
 	# Check if the protocol is in the rule
-	ip_configs[i].ipProtocol == protocol
+	ip_configs[i].IPProtocol == protocol
 
 	# Check if the associated port is also a match
 fw_rule_check_port(	ip_configs[i], port)
@@ -166,10 +166,10 @@ fw_rule_check_port(ip_config, port) {
 	protocol_with_ports := {"tcp", "udp", "all"}
 
 	# only for protocol with ports or "all" - since it includes tcp and udp
-	ip_config.ipProtocol == protocol_with_ports[_]
+	ip_config.IPProtocol == protocol_with_ports[_]
 
 	# if port is not set in ip_config, any port passed as a param matches
-not 	ip_config.port
+not 	ip_config.ports
 }
 
 # fw_rule_check_port when port is a single number
@@ -178,7 +178,7 @@ fw_rule_check_port(ip_config, port) {
 	not re_match("-", port)
 
 	# check if the port matches
-	rule_ports := ip_config.port
+	rule_ports := ip_config.ports
 
 	# check if port is in one of rule_ports values
 port_is_in_values(	port, rule_ports[_])
@@ -190,7 +190,7 @@ fw_rule_check_port(ip_config, port) {
 	re_match("-", port)
 
 	# check if the port range is included in the fw_rule port
-	rule_ports := ip_config.port
+	rule_ports := ip_config.ports
 
 	rule_port := rule_ports[_]
 
@@ -260,11 +260,11 @@ fw_rule_check_all_sources(fw_rule, params) {
 
 # fw_rule_check_source when source range is passed
 fw_rule_check_source_range(fw_rule, source_range) {
-	# test if sourceRange exists in the rule
-	fw_rule.sourceRange
+	# test if sourceRanges exists in the rule
+	fw_rule.sourceRanges
 
 	# check that source ranges are set
-	fw_rule_ranges = fw_rule.sourceRange
+	fw_rule_ranges = fw_rule.sourceRanges
 
 	# check if any range matches
 	# no CIDR matching logic at this time
@@ -276,7 +276,7 @@ fw_rule_check_source_range(fw_rule, source_range) {
 	source_range == "*"
 
 	# Check that at least a source range is set
-	fw_rule.sourceRange
+	fw_rule.sourceRanges
 }
 
 # fw_rule_check_source_range if source_ranges is set to any (default)
@@ -289,7 +289,7 @@ fw_rule_check_source_tag(fw_rule, source_tag) {
 	source_tag != "*"
 
 	# check that the rule source tags are set
-	fw_rule_source_tags := fw_rule.sourceTag
+	fw_rule_source_tags := fw_rule.sourceTags
 
 	# check if the input tag matches any tag in the rule
 re_match(	source_tag, fw_rule_source_tags[_])
@@ -300,7 +300,7 @@ fw_rule_check_source_tag(fw_rule, source_tag) {
 	source_tag == "*"
 
 	# Verify that we have a source tag set, regardless of its value
-	fw_rule.sourceTag
+	fw_rule.sourceTags
 }
 
 # fw_rule_check_source_tag if source tag is set to any (default)
@@ -313,7 +313,7 @@ fw_rule_check_source_sas(fw_rule, source_service_account) {
 	source_service_account != "*"
 
 	# check that source service accounts are set
-	fw_rule_source_sas = fw_rule.sourceServiceAccount
+	fw_rule_source_sas = fw_rule.sourceServiceAccounts
 
 	# check if the rule service account matches
 re_match(	source_service_account, fw_rule_source_sas[_])
@@ -324,7 +324,7 @@ fw_rule_check_source_sas(fw_rule, source_service_account) {
 	source_service_account == "*"
 
 	# Verify that we have a source service account set, regardless of its value
-	fw_rule.sourceServiceAccount
+	fw_rule.sourceServiceAccounts
 }
 
 # fw_rule_check_source_sas if source service account is set to any
@@ -345,11 +345,11 @@ fw_rule_check_all_targets(fw_rule, params) {
 
 # fw_rule_check_target when target range is passed
 fw_rule_check_target_range(fw_rule, target_range) {
-	# test if destinationRange exists in the rule
-	fw_rule.destinationRange
+	# test if destinationRanges exists in the rule
+	fw_rule.destinationRanges
 
 	# check that target ranges are set
-	fw_rule_ranges = fw_rule.destinationRange
+	fw_rule_ranges = fw_rule.destinationRanges
 
 	# check if any range matches
 	# no CIDR matching logic at this time
@@ -361,7 +361,7 @@ fw_rule_check_target_range(fw_rule, target_range) {
 	target_range == "*"
 
 	# Check that at least a target range is set
-	fw_rule.destinationRange
+	fw_rule.destinationRanges
 }
 
 # fw_rule_check_target_range if target_ranges is set to any (default)
@@ -374,7 +374,7 @@ fw_rule_check_target_tag(fw_rule, target_tag) {
 	target_tag != "*"
 
 	# check that the rule target tags are set
-	fw_rule_target_tags := fw_rule.targetTag
+	fw_rule_target_tags := fw_rule.targetTags
 
 	# check if the input tag matches any tag in the rule
 re_match(	target_tag, fw_rule_target_tags[_])
@@ -385,7 +385,7 @@ fw_rule_check_target_tag(fw_rule, target_tag) {
 	target_tag == "*"
 
 	# Verify that we have a target tag set, regardless of its value
-	fw_rule.targetTag
+	fw_rule.targetTags
 }
 
 # fw_rule_check_target_tag if target tag is set to any (default)
@@ -398,7 +398,7 @@ fw_rule_check_target_sas(fw_rule, target_service_account) {
 	target_service_account != "*"
 
 	# check that target service accounts are set
-	fw_rule_target_sas = fw_rule.targetServiceAccount
+	fw_rule_target_sas = fw_rule.targetServiceAccounts
 
 	# check if the rule service account matches
 re_match(	target_service_account, fw_rule_target_sas[_])
@@ -409,7 +409,7 @@ fw_rule_check_target_sas(fw_rule, target_service_account) {
 	target_service_account == "*"
 
 	# Verify that we have a target service account set, regardless of its value
-	fw_rule.targetServiceAccount
+	fw_rule.targetServiceAccounts
 }
 
 # fw_rule_check_target_sas if target service account is set to any

--- a/validator/test/fixtures/restricted_firewall_rules/assets/protocol_and_port/data.json
+++ b/validator/test/fixtures/restricted_firewall_rules/assets/protocol_and_port/data.json
@@ -10,17 +10,17 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "icmp"
+                        "IPProtocol": "icmp"
                     },
                     {
-                        "ipProtocol": "tcp",
-                        "port": [
+                        "IPProtocol": "tcp",
+                        "ports": [
                             "123"
                         ]
                     },
                     {
-                        "ipProtocol": "udp",
-                        "port": [
+                        "IPProtocol": "udp",
+                        "ports": [
                             "1000-7000"
                         ]
                     }
@@ -37,10 +37,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 65534,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/default-allow-rdp",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -57,18 +57,18 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "tcp",
-                        "port": [
+                        "IPProtocol": "tcp",
+                        "ports": [
                             "20",
                             "50-160",
                             "3000-3010"
                         ]
                     },
                     {
-                        "ipProtocol": "icmp"
+                        "IPProtocol": "icmp"
                     },
                     {
-                        "ipProtocol": "sctp"
+                        "IPProtocol": "sctp"
                     }
                 ],
                 "creationTimestamp": "2019-08-01T12:29:43.984-07:00",
@@ -83,10 +83,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-1",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -104,7 +104,7 @@
                 "creationTimestamp": "2019-08-01T12:33:34.710-07:00",
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "description": "",
@@ -118,10 +118,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-2",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -139,7 +139,7 @@
                 "creationTimestamp": "2019-08-01T12:34:29.409-07:00",
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "description": "",
@@ -153,10 +153,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-3",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -173,14 +173,14 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "udp",
-                        "port": [
+                        "IPProtocol": "udp",
+                        "ports": [
                             "234"
                         ]
                     },
                     {
-                        "ipProtocol": "tcp",
-                        "port": [
+                        "IPProtocol": "tcp",
+                        "ports": [
                             "22", "100-300", "2000-6100"
                         ]
                     }
@@ -197,10 +197,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-4",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -217,7 +217,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-01T15:32:41.698-07:00",
@@ -232,10 +232,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-5",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -252,22 +252,22 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "tcp"
+                        "IPProtocol": "tcp"
                     },
                     {
-                        "ipProtocol": "udp",
-                        "port": [
+                        "IPProtocol": "udp",
+                        "ports": [
                             "5200"
                         ]
                     },
                     {
-                        "ipProtocol": "ah"
+                        "IPProtocol": "ah"
                     },
                     {
-                        "ipProtocol": "sctp"
+                        "IPProtocol": "sctp"
                     },
                     {
-                        "ipProtocol": "icmp"
+                        "IPProtocol": "icmp"
                     }
                 ],
                 "creationTimestamp": "2019-08-09T09:28:30.215-07:00",
@@ -282,10 +282,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-6",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -302,8 +302,8 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "tcp",
-                        "port": [
+                        "IPProtocol": "tcp",
+                        "ports": [
                             "234"
                         ]
                     }
@@ -320,14 +320,13 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-7",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
         }
     }
 ]
-

--- a/validator/test/fixtures/restricted_firewall_rules/assets/sources/data.json
+++ b/validator/test/fixtures/restricted_firewall_rules/assets/sources/data.json
@@ -10,7 +10,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-01-03T18:17:04.307-08:00",
@@ -25,13 +25,13 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 65534,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/default-allow-rdp",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "sourceTag": [
+                "sourceTags": [
                     "source-tag"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -48,7 +48,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-01T12:29:43.984-07:00",
@@ -63,10 +63,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-1",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -84,7 +84,7 @@
                 "creationTimestamp": "2019-08-01T12:33:34.710-07:00",
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "description": "",
@@ -98,10 +98,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-2",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -119,7 +119,7 @@
                 "creationTimestamp": "2019-08-01T12:34:29.409-07:00",
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "description": "",
@@ -133,13 +133,13 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-3",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "sourceTag": [
+                "sourceTags": [
                     "bad-tag"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -156,7 +156,7 @@
             "data": {
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-01T12:52:26.839-07:00",
@@ -171,13 +171,13 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-4",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "sourceTag": [
+                "sourceTags": [
                     "source-tag-4"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -194,7 +194,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-01T15:32:41.698-07:00",
@@ -209,13 +209,13 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-5",
-                "sourceRange": [
+                "sourceRanges": [
                     "192.1.0.0/16"
                 ],
-                "sourceTag": [
+                "sourceTags": [
                     "source-tag-1"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -232,7 +232,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-09T09:28:30.215-07:00",
@@ -247,13 +247,13 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-6",
-                "sourceTag": [
+                "sourceTags": [
                     "source-tag-1"
                 ],
-                "sourceServiceAccount": [
+                "sourceServiceAccounts": [
                     "cf-gcp-challenge-dev-sa-source@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -270,7 +270,7 @@
             "data": {
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-09T12:53:34.847-07:00",
@@ -285,14 +285,14 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-7",
-                "sourceRange": [
+                "sourceRanges": [
                     "10.0.0.0/24",
                     "10.1.0.0/24",
                     "10.2.0.0/24",
                     "10.3.0.0/24",
                     "10.4.0.0/24"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -309,12 +309,12 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2018-12-05T08:17:39.527-08:00",
                 "description": "",
-                "destinationRange": [
+                "destinationRanges": [
                     "0.0.0.0/0"
                 ],
                 "direction": "EGRESS",
@@ -342,11 +342,11 @@
                 "creationTimestamp": "2019-08-13T12:04:05.918-07:00",
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "description": "",
-                "destinationRange": [
+                "destinationRanges": [
                     "10.0.0.0/24"
                 ],
                 "direction": "EGRESS",
@@ -359,7 +359,7 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-9",
-                "targetTag": [
+                "targetTags": [
                     "target-tag"
                 ]
             }
@@ -376,12 +376,12 @@
             "data": {
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-13T12:04:38.423-07:00",
                 "description": "",
-                "destinationRange": [
+                "destinationRanges": [
                     "10.0.0.0/24"
                 ],
                 "direction": "EGRESS",
@@ -408,12 +408,12 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-13T12:05:17.297-07:00",
                 "description": "",
-                "destinationRange": [
+                "destinationRanges": [
                     "10.0.0.0/24"
                 ],
                 "direction": "EGRESS",
@@ -426,7 +426,7 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-source-11",
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }

--- a/validator/test/fixtures/restricted_firewall_rules/assets/targets/data.json
+++ b/validator/test/fixtures/restricted_firewall_rules/assets/targets/data.json
@@ -10,7 +10,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-01-03T18:17:04.307-08:00",
@@ -25,10 +25,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 65534,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/default-allow-rdp",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -45,7 +45,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-01T12:29:43.984-07:00",
@@ -60,10 +60,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-1",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -81,7 +81,7 @@
                 "creationTimestamp": "2019-08-01T12:33:34.710-07:00",
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "description": "",
@@ -95,10 +95,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-2",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -116,7 +116,7 @@
                 "creationTimestamp": "2019-08-01T12:34:29.409-07:00",
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "description": "",
@@ -130,13 +130,13 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-3",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "sourceTag": [
+                "sourceTags": [
                     "bad-tag"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -153,7 +153,7 @@
             "data": {
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-01T12:52:26.839-07:00",
@@ -168,10 +168,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-4",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -188,7 +188,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-01T15:32:41.698-07:00",
@@ -203,10 +203,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-5",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -223,7 +223,7 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-09T09:28:30.215-07:00",
@@ -238,10 +238,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-6",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -258,7 +258,7 @@
             "data": {
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-09T12:53:34.847-07:00",
@@ -273,10 +273,10 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-7",
-                "sourceRange": [
+                "sourceRanges": [
                     "0.0.0.0/0"
                 ],
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }
@@ -293,12 +293,12 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2018-12-05T08:17:39.527-08:00",
                 "description": "",
-                "destinationRange": [
+                "destinationRanges": [
                     "0.0.0.0/0"
                 ],
                 "direction": "EGRESS",
@@ -326,11 +326,11 @@
                 "creationTimestamp": "2019-08-13T12:04:05.918-07:00",
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "description": "",
-                "destinationRange": [
+                "destinationRanges": [
                     "10.0.0.0/24"
                 ],
                 "direction": "EGRESS",
@@ -343,7 +343,7 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-9",
-                "targetTag": [
+                "targetTags": [
                     "target-tag"
                 ]
             }
@@ -360,12 +360,12 @@
             "data": {
                 "denied": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-13T12:04:38.423-07:00",
                 "description": "",
-                "destinationRange": [
+                "destinationRanges": [
                     "10.0.0.0/24"
                 ],
                 "direction": "EGRESS",
@@ -392,12 +392,12 @@
             "data": {
                 "allowed": [
                     {
-                        "ipProtocol": "all"
+                        "IPProtocol": "all"
                     }
                 ],
                 "creationTimestamp": "2019-08-13T12:05:17.297-07:00",
                 "description": "",
-                "destinationRange": [
+                "destinationRanges": [
                     "10.0.0.0/24"
                 ],
                 "direction": "EGRESS",
@@ -410,7 +410,7 @@
                 "network": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/networks/default",
                 "priority": 1000,
                 "selfLink": "https://www.googleapis.com/compute/v1/projects/cf-gcp-challenge-dev/global/firewalls/cf-test-fw-rule-target-11",
-                "targetServiceAccount": [
+                "targetServiceAccounts": [
                     "cf-gcp-challenge-dev-sa@cf-gcp-challenge-dev.iam.gserviceaccount.com"
                 ]
             }

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/advanced/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/advanced/data.yaml
@@ -17,11 +17,11 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPRestrictedFirewallRulesConstraintV1
 eetadata:
-  name: restrict-firewall-rules-udp-port-1000-to-6000
+  name: restrict-firewall-rules-udp-ports-1000-to-6000
 spec:
   severity: high
   match:
     target: ["organization/*"]
   parameters:
-    port: "2000-2100"
+    ports: "2000-2100"
     protocol: "udp"

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/basic/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/basic/data.yaml
@@ -17,11 +17,11 @@
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPRestrictedFirewallRulesConstraintV1
 eetadata:
-  name: restrict-firewall-rule-tcp-port-6001
+  name: restrict-firewall-rule-tcp-ports-6001
 spec:
   severity: high
   match:
     target: ["organization/*"]
   parameters:
-    port: "6001"
+    ports: "6001"
     protocol: "tcp"


### PR DESCRIPTION
Updated firewall rule rego and test data to account for [CAI field name updates](https://cloud.google.com/asset-inventory/docs/naming-table).

I did some more Forseti testing and my test rules are now being correctly scanned based on how I change the constraint. I tested various combinations of the parameters: protocol, port, source_ranges, target_tags. Things look to be working as expected.

I need to get my local dev environment setup, and currently not able to run `make test`. Will try to get that setup for the future.