### PR TITLE
Fixed the Restricted FW Rule tests

### DIFF
--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/advanced/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/advanced/data.yaml
@@ -16,12 +16,12 @@
 
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPRestrictedFirewallRulesConstraintV1
-eetadata:
+metadata:
   name: restrict-firewall-rules-udp-ports-1000-to-6000
 spec:
   severity: high
   match:
     target: ["organization/*"]
   parameters:
-    ports: "2000-2100"
+    port: "2000-2100"
     protocol: "udp"

--- a/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/basic/data.yaml
+++ b/validator/test/fixtures/restricted_firewall_rules/constraints/protocol_and_port/basic/data.yaml
@@ -16,12 +16,12 @@
 
 apiVersion: constraints.gatekeeper.sh/v1alpha1
 kind: GCPRestrictedFirewallRulesConstraintV1
-eetadata:
+metadata:
   name: restrict-firewall-rule-tcp-ports-6001
 spec:
   severity: high
   match:
     target: ["organization/*"]
   parameters:
-    ports: "6001"
+    port: "6001"
     protocol: "tcp"


### PR DESCRIPTION
Fixed the firewall tests; the port parameter of the test contraints was accidentally updated to ports when I was updating the template and test data.